### PR TITLE
FIX: solves bug with interleave and no pad

### DIFF
--- a/sthor/model/parameters/isbi12.py
+++ b/sthor/model/parameters/isbi12.py
@@ -1,0 +1,97 @@
+from copy import deepcopy
+
+try:
+    import pyll
+    choice = pyll.scope.choice
+    pyll_available = True
+except ImportError:
+    pyll_available = False
+
+if pyll_available:
+    # -- lnorm
+    _lnorm_shape = choice([
+        (3, 3),
+        (5, 5),
+        (9, 9),
+        (17, 17),
+    ])
+    _lnorm = {
+        'kwargs': {
+            'inker_shape': _lnorm_shape,
+            'outker_shape' : _lnorm_shape,
+            'remove_mean' : choice([False, True]),
+            'stretch' : choice([1.]),
+            'threshold' : choice([1.])
+        }
+    }
+
+
+    # -- fbcorr
+    _fbcorr_shape = choice([
+        (3, 3),
+        (5, 5),
+        (9, 9),
+        (17, 17),
+    ])
+    _fbcorr = {
+        'initialize': {
+            'filter_shape': _fbcorr_shape,
+            'n_filters': choice([16, 32, 64]),
+            'generate': ('random:uniform', {'rseed': 42}),
+        },
+        'kwargs': {
+            'min_out': choice([0]),
+            'max_out': choice([1, None]),
+        }
+    }
+    _fbcorr1 = deepcopy(_fbcorr)
+    _fbcorr1['initialize']['n_filters'] = choice([64])
+    _fbcorr2 = deepcopy(_fbcorr)
+    _fbcorr2['initialize']['n_filters'] = choice([64, 128])
+    _fbcorr3 = deepcopy(_fbcorr)
+    _fbcorr3['initialize']['n_filters'] = choice([64, 128, 256])
+    _fbcorr4 = deepcopy(_fbcorr)
+    _fbcorr4['initialize']['n_filters'] = choice([64, 128, 256, 512])
+
+
+    # -- lpool
+    _lpool_shape = choice([
+        (2, 2),
+        (3, 3),
+    ])
+    _lpool = {
+        'kwargs': {
+            'ker_shape': _lpool_shape,
+            'order': choice([1., 2., 10.]),
+            'stride': 2,
+        }
+    }
+
+
+    # --
+    isbi12_l4_description_pyll = [
+        [
+            ('lnorm', deepcopy(_lnorm)),
+        ],
+        [
+            ('fbcorr', deepcopy(_fbcorr1)),
+            ('lpool', deepcopy(_lpool)),
+        ],
+        [
+            ('fbcorr', deepcopy(_fbcorr2)),
+            ('lpool', deepcopy(_lpool)),
+        ],
+        [
+            ('fbcorr', deepcopy(_fbcorr3)),
+            ('lpool', deepcopy(_lpool)),
+        ],
+        [
+            ('fbcorr', deepcopy(_fbcorr4)),
+            ('lpool', deepcopy(_lpool)),
+        ],
+    ]
+
+
+    def get_random_isbi12_l4_description(rng=None):
+        desc = pyll.stochastic.sample(isbi12_l4_description_pyll, rng=rng)
+        return desc

--- a/sthor/model/tests/test_slm.py
+++ b/sthor/model/tests/test_slm.py
@@ -63,7 +63,6 @@ def test_no_description():
 
     assert slm.n_layers == 0
     assert slm.ops_nbh_nbw_stride == []
-    #assert slm.receptive_field_shape == (1, 1)
 
 
 def test_L3_first_desc():
@@ -193,3 +192,54 @@ def test_interleave_no_pad():
     features = model.process(arr, interleave_stride=True)
 
     assert features.shape == (503, 503, 200)
+
+
+mydesc = [
+    [[u'fbcorr',
+      {'initialize': {'filter_shape': (5, 5),
+                      'generate': ('random:uniform', {'rseed': 42}),
+                      'n_filters': 48},
+       u'kwargs': {u'max_out': None, u'min_out': 0}}],
+     [u'lpool', {u'kwargs': {u'ker_shape': [2, 2], u'order': 1, u'stride': 2}}]],
+    [[u'fbcorr',
+      {'initialize': {'filter_shape': (4, 4),
+                      'generate': ('random:uniform', {'rseed': 42}),
+                      'n_filters': 48},
+       u'kwargs': {u'max_out': None, u'min_out': 0}}],
+     [u'lpool', {u'kwargs': {u'ker_shape': [2, 2], u'order': 1, u'stride': 2}}]],
+    [[u'fbcorr',
+      {'initialize': {'filter_shape': (4, 4),
+                      'generate': ('random:uniform', {'rseed': 42}),
+                      'n_filters': 48},
+       u'kwargs': {u'max_out': None, u'min_out': 0}}],
+     [u'lpool', {u'kwargs': {u'ker_shape': [2, 2], u'order': 2, u'stride': 2}}]],
+    [[u'fbcorr',
+      {'initialize': {'filter_shape': (4, 4),
+                      'generate': ('random:uniform', {'rseed': 42}),
+                      'n_filters': 48},
+       u'kwargs': {u'max_out': 1., u'min_out': 0}}],
+     [u'lpool', {u'kwargs': {u'ker_shape': [2, 2], u'order': 10, u'stride': 2}}]],
+    [[u'fbcorr',
+      {'initialize': {'filter_shape': (3, 3),
+                      'generate': ('random:uniform', {'rseed': 42}),
+                      'n_filters': 200},
+       u'kwargs': {u'max_out': None, u'min_out': 0}}]]
+]
+
+
+def test_get_in_shape():
+
+    from sthor.model.slm import _get_in_shape
+
+    out_shape = (512, 512)
+
+    success, in_shape, final_out_shape = _get_in_shape(out_shape,
+                                                       mydesc,
+                                                       interleave_stride=True)
+
+    assert success
+    assert in_shape == (605, 605)
+
+
+if __name__ == "__main__":
+  main()

--- a/sthor/model/tests/test_slm.py
+++ b/sthor/model/tests/test_slm.py
@@ -63,7 +63,7 @@ def test_no_description():
 
     assert slm.n_layers == 0
     assert slm.ops_nbh_nbw_stride == []
-    assert slm.receptive_field_shape == (1, 1)
+    #assert slm.receptive_field_shape == (1, 1)
 
 
 def test_L3_first_desc():
@@ -83,7 +83,7 @@ def test_L3_first_desc():
                                       ('fbcorr', 5, 5, 1),
                                       ('lpool', 7, 7, 2),
                                       ('lnorm', 3, 3, 1)]
-    assert slm.receptive_field_shape == (121, 121)
+    #assert slm.receptive_field_shape == (121, 121)
 
 
 def test_null_image_same_size_as_receptive_field():
@@ -168,3 +168,28 @@ def test_outout_with_interleave_and_stride_and_no_interleave():
     features = slm.process(img, pad_apron=True, interleave_stride=False)
 
     assert_allclose(features, full_features[::8, ::8], rtol=RTOL, atol=ATOL)
+
+
+desc = \
+[[('fbcorr',
+   {'initialize': {'filter_shape': (5, 5),
+                   'generate': ('random:uniform', {'rseed': 42}),
+                   'n_filters': 48},
+    'kwargs': {'max_out': None, 'min_out': 0}}),
+  ('lpool', {'kwargs': {'ker_shape': [2, 2], 'order': 10, 'stride': 2}})],
+ [('fbcorr',
+   {'initialize': {'filter_shape': (3, 3),
+                   'generate': ('random:uniform', {'rseed': 42}),
+                   'n_filters': 200},
+    'kwargs': {'max_out': None, 'min_out': 0}})]]
+
+
+def test_interleave_no_pad():
+
+    model = SequentialLayeredModel((512, 512), desc)
+
+    arr = np.random.randn(512, 512).astype('f')
+
+    features = model.process(arr, interleave_stride=True)
+
+    assert features.shape == (503, 503, 200)


### PR DESCRIPTION
Here is a working code that solves the bug found in issue # 10.

It turns out that my previous function that was computing the receptive field
was wrong. One cannot compute the receptive field other than when executing
the code on an actual test image and look at the final shape of the array.

The reason has to do with the fact that when some operations have strides, more
than one shape of input array can lead to the same final shape for the output arrays.

I added the bug as a test in the SLM class test suite.
